### PR TITLE
Add browser DAW with piano roll and drum sequencer

### DIFF
--- a/daw/app.js
+++ b/daw/app.js
@@ -1,0 +1,392 @@
+const steps = 16;
+const pianoNotes = [
+  "C5",
+  "B4",
+  "A#4",
+  "A4",
+  "G#4",
+  "G4",
+  "F#4",
+  "F4",
+  "E4",
+  "D#4",
+  "D4",
+  "C4"
+];
+const drumTracks = [
+  { id: "kick", label: "Kick" },
+  { id: "snare", label: "Snare" },
+  { id: "hat", label: "Hi-Hat" }
+];
+
+const pianoGrid = document.getElementById("pianoGrid");
+const drumGrid = document.getElementById("drumGrid");
+const tempoInput = document.getElementById("tempo");
+const tempoDisplay = document.getElementById("tempoDisplay");
+const playButton = document.getElementById("playButton");
+const stopButton = document.getElementById("stopButton");
+const swingInput = document.getElementById("swing");
+const swingDisplay = document.getElementById("swingDisplay");
+
+const pianoState = pianoNotes.map(() => Array(steps).fill(false));
+const drumState = drumTracks.map(() => Array(steps).fill(false));
+const pianoCells = pianoNotes.map(() => Array(steps));
+const drumCells = drumTracks.map(() => Array(steps));
+
+let audioCtx;
+let masterGain;
+let noiseBuffer;
+let isPlaying = false;
+let currentStep = 0;
+let timerId;
+
+buildPianoGrid();
+buildDrumGrid();
+updateTempoDisplay();
+updateSwingDisplay();
+seedDemoPattern();
+stopButton.disabled = true;
+
+playButton.addEventListener("click", startPlayback);
+stopButton.addEventListener("click", stopPlayback);
+tempoInput.addEventListener("input", () => {
+  updateTempoDisplay();
+});
+swingInput.addEventListener("input", () => {
+  updateSwingDisplay();
+});
+
+function buildPianoGrid() {
+  pianoGrid.innerHTML = "";
+  pianoNotes.forEach((note, rowIndex) => {
+    const row = document.createElement("div");
+    row.className = "note-row";
+    const label = document.createElement("div");
+    label.className = "note-label";
+    label.textContent = note;
+    row.appendChild(label);
+
+    for (let stepIndex = 0; stepIndex < steps; stepIndex += 1) {
+      const cell = createCell("piano", rowIndex, stepIndex);
+      row.appendChild(cell);
+      pianoCells[rowIndex][stepIndex] = cell;
+    }
+
+    pianoGrid.appendChild(row);
+  });
+}
+
+function buildDrumGrid() {
+  drumGrid.innerHTML = "";
+
+  drumTracks.forEach((track, rowIndex) => {
+    const row = document.createElement("div");
+    row.className = "pattern-row";
+    const label = document.createElement("div");
+    label.className = "note-label";
+    label.textContent = track.label;
+    row.appendChild(label);
+
+    for (let stepIndex = 0; stepIndex < steps; stepIndex += 1) {
+      const cell = createCell("drum", rowIndex, stepIndex);
+      row.appendChild(cell);
+      drumCells[rowIndex][stepIndex] = cell;
+    }
+
+    drumGrid.appendChild(row);
+  });
+}
+
+function seedDemoPattern() {
+  const melody = [
+    { note: "C5", steps: [0, 4, 8, 12] },
+    { note: "G4", steps: [2, 6, 10, 14] },
+    { note: "E4", steps: [4, 12] },
+    { note: "D4", steps: [7, 15] }
+  ];
+
+  melody.forEach(({ note, steps: activeSteps }) => {
+    const rowIndex = pianoNotes.indexOf(note);
+    if (rowIndex === -1) return;
+    activeSteps.forEach((stepIndex) => {
+      pianoState[rowIndex][stepIndex] = true;
+      const button = pianoCells[rowIndex][stepIndex].querySelector("button");
+      button.classList.add("active");
+    });
+  });
+
+  const drumPattern = {
+    kick: [0, 4, 8, 12],
+    snare: [4, 12],
+    hat: Array.from({ length: steps }, (_, index) => index).filter(
+      (index) => index % 2 === 0
+    )
+  };
+
+  drumTracks.forEach(({ id }, rowIndex) => {
+    const activeSteps = drumPattern[id] || [];
+    activeSteps.forEach((stepIndex) => {
+      drumState[rowIndex][stepIndex] = true;
+      const button = drumCells[rowIndex][stepIndex].querySelector("button");
+      button.classList.add("active");
+    });
+  });
+}
+
+function createCell(type, rowIndex, stepIndex) {
+  const cell = document.createElement("div");
+  cell.className = "cell";
+  const button = document.createElement("button");
+  button.type = "button";
+  button.addEventListener("click", () => {
+    const isActive = toggleCell(type, rowIndex, stepIndex);
+    button.classList.toggle("active", isActive);
+  });
+  cell.appendChild(button);
+  return cell;
+}
+
+function toggleCell(type, rowIndex, stepIndex) {
+  if (type === "piano") {
+    pianoState[rowIndex][stepIndex] = !pianoState[rowIndex][stepIndex];
+    return pianoState[rowIndex][stepIndex];
+  }
+
+  drumState[rowIndex][stepIndex] = !drumState[rowIndex][stepIndex];
+  return drumState[rowIndex][stepIndex];
+}
+
+function startPlayback() {
+  if (isPlaying) return;
+
+  const context = ensureAudioContext();
+  context.resume();
+  isPlaying = true;
+  currentStep = 0;
+  highlightStep(null);
+  playButton.disabled = true;
+  stopButton.disabled = false;
+  runStep();
+}
+
+function stopPlayback() {
+  if (!isPlaying) return;
+  isPlaying = false;
+  if (timerId) {
+    clearTimeout(timerId);
+  }
+  timerId = undefined;
+  highlightStep(null);
+  playButton.disabled = false;
+  stopButton.disabled = true;
+}
+
+function runStep() {
+  if (!isPlaying) {
+    return;
+  }
+
+  const context = ensureAudioContext();
+  const tempo = Number.parseInt(tempoInput.value, 10);
+  const swing = Number.parseFloat(swingInput.value);
+  const stepDuration = 60 / tempo / 4;
+  const startTime = context.currentTime + 0.02;
+
+  triggerPiano(currentStep, startTime, stepDuration);
+  triggerDrums(currentStep, startTime);
+  highlightStep(currentStep);
+
+  currentStep = (currentStep + 1) % steps;
+  let nextInterval = stepDuration;
+  if (swing > 0) {
+    const swingAmount = stepDuration * swing;
+    const isEvenStep = currentStep % 2 === 0;
+    nextInterval = isEvenStep ? stepDuration - swingAmount : stepDuration + swingAmount;
+  }
+
+  timerId = setTimeout(runStep, Math.max(0.05, nextInterval) * 1000);
+}
+
+function highlightStep(step) {
+  pianoCells.forEach((row) => {
+    row.forEach((cell, index) => {
+      cell.classList.toggle("playing", step === index);
+    });
+  });
+
+  drumCells.forEach((row) => {
+    row.forEach((cell, index) => {
+      cell.classList.toggle("playing", step === index);
+    });
+  });
+}
+
+function triggerPiano(step, startTime, duration) {
+  const context = ensureAudioContext();
+
+  pianoState.forEach((row, rowIndex) => {
+    if (!row[step]) return;
+    const noteName = pianoNotes[rowIndex];
+    const frequency = noteToFrequency(noteName);
+    playSynthVoice(frequency, startTime, duration);
+  });
+}
+
+function triggerDrums(step, startTime) {
+  drumState.forEach((row, rowIndex) => {
+    if (!row[step]) return;
+
+    const id = drumTracks[rowIndex].id;
+    if (id === "kick") {
+      playKick(startTime);
+    } else if (id === "snare") {
+      playSnare(startTime);
+    } else {
+      playHat(startTime);
+    }
+  });
+}
+
+function ensureAudioContext() {
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+    masterGain = audioCtx.createGain();
+    masterGain.gain.value = 0.6;
+    masterGain.connect(audioCtx.destination);
+  }
+  return audioCtx;
+}
+
+function ensureNoiseBuffer() {
+  if (!noiseBuffer && audioCtx) {
+    noiseBuffer = audioCtx.createBuffer(1, audioCtx.sampleRate, audioCtx.sampleRate);
+    const data = noiseBuffer.getChannelData(0);
+    for (let i = 0; i < noiseBuffer.length; i += 1) {
+      data[i] = Math.random() * 2 - 1;
+    }
+  }
+  return noiseBuffer;
+}
+
+function playSynthVoice(frequency, startTime, duration) {
+  const context = ensureAudioContext();
+  const osc = context.createOscillator();
+  const gain = context.createGain();
+  const filter = context.createBiquadFilter();
+
+  osc.type = "sawtooth";
+  osc.frequency.setValueAtTime(frequency, startTime);
+
+  filter.type = "lowpass";
+  filter.frequency.setValueAtTime(1800, startTime);
+  filter.Q.value = 8;
+
+  gain.gain.setValueAtTime(0.001, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.6, startTime + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.0001, startTime + duration * 1.5);
+
+  osc.connect(filter);
+  filter.connect(gain);
+  gain.connect(masterGain);
+
+  osc.start(startTime);
+  osc.stop(startTime + duration * 1.6);
+}
+
+function playKick(startTime) {
+  const context = ensureAudioContext();
+  const osc = context.createOscillator();
+  const gain = context.createGain();
+
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(120, startTime);
+  osc.frequency.exponentialRampToValueAtTime(40, startTime + 0.32);
+
+  gain.gain.setValueAtTime(1, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, startTime + 0.32);
+
+  osc.connect(gain);
+  gain.connect(masterGain);
+
+  osc.start(startTime);
+  osc.stop(startTime + 0.4);
+}
+
+function playSnare(startTime) {
+  const context = ensureAudioContext();
+  const noise = context.createBufferSource();
+  noise.buffer = ensureNoiseBuffer();
+
+  const noiseFilter = context.createBiquadFilter();
+  noiseFilter.type = "bandpass";
+  noiseFilter.frequency.setValueAtTime(1800, startTime);
+  noiseFilter.Q.value = 0.8;
+
+  const noiseGain = context.createGain();
+  noiseGain.gain.setValueAtTime(0.7, startTime);
+  noiseGain.gain.exponentialRampToValueAtTime(0.01, startTime + 0.2);
+
+  const tone = context.createOscillator();
+  tone.type = "triangle";
+  tone.frequency.setValueAtTime(200, startTime);
+  tone.frequency.exponentialRampToValueAtTime(120, startTime + 0.18);
+
+  const toneGain = context.createGain();
+  toneGain.gain.setValueAtTime(0.4, startTime);
+  toneGain.gain.exponentialRampToValueAtTime(0.01, startTime + 0.18);
+
+  noise.connect(noiseFilter).connect(noiseGain).connect(masterGain);
+  tone.connect(toneGain).connect(masterGain);
+
+  noise.start(startTime);
+  noise.stop(startTime + 0.25);
+  tone.start(startTime);
+  tone.stop(startTime + 0.2);
+}
+
+function playHat(startTime) {
+  const context = ensureAudioContext();
+  const noise = context.createBufferSource();
+  noise.buffer = ensureNoiseBuffer();
+
+  const highpass = context.createBiquadFilter();
+  highpass.type = "highpass";
+  highpass.frequency.setValueAtTime(8000, startTime);
+  highpass.Q.value = 0.7;
+
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0.4, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.005, startTime + 0.12);
+
+  noise.connect(highpass).connect(gain).connect(masterGain);
+  noise.start(startTime);
+  noise.stop(startTime + 0.15);
+}
+
+function noteToFrequency(note) {
+  const [pitch, octave] = note.match(/([A-G]#?)(\d)/).slice(1);
+  const semitoneMap = {
+    C: -9,
+    "C#": -8,
+    D: -7,
+    "D#": -6,
+    E: -5,
+    F: -4,
+    "F#": -3,
+    G: -2,
+    "G#": -1,
+    A: 0,
+    "A#": 1,
+    B: 2
+  };
+  const semitonesFromA4 = (Number.parseInt(octave, 10) - 4) * 12 + semitoneMap[pitch];
+  return 440 * 2 ** (semitonesFromA4 / 12);
+}
+
+function updateTempoDisplay() {
+  tempoDisplay.textContent = `${tempoInput.value} BPM`;
+}
+
+function updateSwingDisplay() {
+  swingDisplay.textContent = `${Math.round(Number.parseFloat(swingInput.value) * 100)}%`;
+}

--- a/daw/index.html
+++ b/daw/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Browser DAW</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Digital Audio Workstation</h1>
+      <p>
+        Disegna melodie nel piano roll, programma un groove di batteria e premi
+        play per ascoltare il tuo loop.
+      </p>
+    </header>
+
+    <main class="workspace">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Piano Roll</h2>
+          <div class="controls">
+            <label for="tempo">Tempo</label>
+            <input id="tempo" type="range" min="60" max="180" value="110" />
+            <output id="tempoDisplay">110 BPM</output>
+          </div>
+        </div>
+        <div id="pianoGrid" class="grid"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Batteria</h2>
+          <p class="panel-subtitle">Kick, Snare, Hi-Hat su sedicesimi</p>
+        </div>
+        <div id="drumGrid" class="grid drum-grid"></div>
+      </section>
+    </main>
+
+    <footer class="transport">
+      <button id="playButton" class="primary">Play</button>
+      <button id="stopButton">Stop</button>
+      <label class="swing-control">
+        Swing
+        <input id="swing" type="range" min="0" max="0.2" step="0.01" value="0" />
+        <output id="swingDisplay">0%</output>
+      </label>
+    </footer>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/daw/styles.css
+++ b/daw/styles.css
@@ -1,0 +1,331 @@
+:root {
+  color-scheme: dark;
+  font-family: "DM Sans", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg: #0d1117;
+  --surface: #161b22;
+  --surface-strong: #1f2530;
+  --primary: #4ade80;
+  --primary-soft: rgba(74, 222, 128, 0.2);
+  --grid-line: #2b3240;
+  --grid-accent: #3b4456;
+  --text: #f8fafc;
+  --text-muted: #94a3b8;
+  --danger: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, #1e293b, #0f172a 60%);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 2.5rem 5vw 1.5rem;
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.1), transparent 60%);
+  text-align: center;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0 0 0.6rem;
+}
+
+.app-header p {
+  margin: 0;
+  color: var(--text-muted);
+  max-width: 40rem;
+  margin-inline: auto;
+}
+
+.workspace {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 5vw 2rem;
+}
+
+@media (min-width: 960px) {
+  .workspace {
+    grid-template-columns: 1fr 0.8fr;
+    align-items: start;
+  }
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 40px 100px rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.panel-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-muted);
+}
+
+.controls input[type="range"] {
+  accent-color: var(--primary);
+}
+
+.grid {
+  display: grid;
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: var(--surface-strong);
+  --steps: 16;
+  --notes: 12;
+  --label-width: 0rem;
+}
+
+.grid::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      to right,
+      transparent calc(100% - 1px),
+      var(--grid-line) calc(100% - 1px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(100% - 1px),
+      var(--grid-line) calc(100% - 1px)
+    );
+  background-size: calc((100% - var(--label-width)) / var(--steps)) 100%,
+    100% calc(100% / var(--notes));
+  background-position: var(--label-width) 0, 0 0;
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.grid .cell {
+  position: relative;
+  isolation: isolate;
+}
+
+.grid .cell button {
+  all: unset;
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.grid .cell button.active {
+  background: var(--primary-soft);
+  box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.5);
+}
+
+.grid .cell button.active::after {
+  content: "";
+  position: absolute;
+  inset: 15%;
+  border-radius: 0.45rem;
+  background: var(--primary);
+  opacity: 0.8;
+}
+
+.grid .cell button:hover:not(.active) {
+  background: rgba(148, 163, 184, 0.06);
+}
+
+.grid .cell.playing button {
+  transform: scaleY(1.05);
+  box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.2);
+}
+
+.transport {
+  margin: auto 5vw 3rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem 1.5rem;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 999px;
+  backdrop-filter: blur(8px);
+}
+
+.transport button,
+.transport label {
+  font-size: 1rem;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.transport button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.transport .primary {
+  background: var(--primary);
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.transport button:active {
+  transform: scale(0.97);
+}
+
+.swing-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--text-muted);
+}
+
+.swing-control input {
+  accent-color: var(--primary);
+}
+
+.swing-control output {
+  min-width: 2.5ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.note-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  padding-left: 0.5rem;
+  font-weight: 600;
+}
+
+.note-row {
+  position: relative;
+}
+
+.note-row:nth-child(odd) .cell button {
+  background: rgba(148, 163, 184, 0.03);
+}
+
+.note-row:nth-child(odd) .cell button.active {
+  background: rgba(74, 222, 128, 0.24);
+}
+
+.note-row:nth-child(odd) .cell button.active::after {
+  opacity: 0.9;
+}
+
+.pattern-row:nth-child(odd) .cell button {
+  background: rgba(148, 163, 184, 0.03);
+}
+
+.pattern-row:nth-child(odd) .cell button.active {
+  background: rgba(74, 222, 128, 0.24);
+}
+
+.note-row:nth-child(4n + 1) .cell button::before,
+.note-row:nth-child(4n + 2) .cell button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(148, 163, 184, 0.025);
+  z-index: -1;
+}
+
+@media (max-width: 720px) {
+  .grid {
+    aspect-ratio: 16 / 12;
+  }
+
+  .drum-grid {
+    aspect-ratio: 16 / 3;
+  }
+}
+
+#pianoGrid {
+  display: block;
+  position: relative;
+  --label-width: clamp(2.2rem, 12vw, 3.2rem);
+  --notes: 12;
+}
+
+#pianoGrid .note-row {
+  display: grid;
+  grid-template-columns: var(--label-width) repeat(16, minmax(0, 1fr));
+  min-height: 2.5rem;
+  position: relative;
+  align-items: stretch;
+}
+
+#drumGrid {
+  display: block;
+  --label-width: clamp(2.2rem, 12vw, 3.2rem);
+  --notes: 3;
+}
+
+.pattern-row {
+  display: grid;
+  grid-template-columns: var(--label-width) repeat(16, minmax(0, 1fr));
+  min-height: 2.75rem;
+  position: relative;
+  align-items: stretch;
+}
+
+.legend {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.legend span {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.legend span::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 2px;
+  background: var(--primary);
+  opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
- add a standalone DAW page with tempo, swing and transport controls
- implement a piano roll and drum sequencer powered by the Web Audio API
- apply responsive styling for the workstation layout and interactive cells

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc4bbc9bbc832e926aed59514bc86e