### PR TITLE
Restyle DAW and add arrangement and synth controls

### DIFF
--- a/daw/app.js
+++ b/daw/app.js
@@ -1,0 +1,780 @@
+const steps = 16;
+const pianoNotes = [
+  "C5",
+  "B4",
+  "A#4",
+  "A4",
+  "G#4",
+  "G4",
+  "F#4",
+  "F4",
+  "E4",
+  "D#4",
+  "D4",
+  "C#4",
+  "C4"
+];
+
+const drumTracks = [
+  { id: "kick", label: "Kick" },
+  { id: "snare", label: "Snare" },
+  { id: "hat", label: "Hi-Hat" }
+];
+
+const synthPresets = {
+  "aurora-lead": {
+    id: "aurora-lead",
+    name: "Aurora Lead",
+    oscillators: [
+      { type: "sawtooth", detune: -8 },
+      { type: "sawtooth", detune: 8 }
+    ],
+    filterCutoff: 3200,
+    filterResonance: 11,
+    envelope: { attack: 0.02, decay: 0.18, sustain: 0.62, release: 0.45 },
+    gain: 0.55
+  },
+  "midnight-pad": {
+    id: "midnight-pad",
+    name: "Midnight Pad",
+    oscillators: [
+      { type: "triangle", detune: -4 },
+      { type: "sine", detune: 6 }
+    ],
+    filterCutoff: 2000,
+    filterResonance: 8,
+    envelope: { attack: 0.35, decay: 0.7, sustain: 0.8, release: 1.8 },
+    gain: 0.5
+  },
+  "glacier-pluck": {
+    id: "glacier-pluck",
+    name: "Glacier Pluck",
+    oscillators: [
+      { type: "square", detune: 0 },
+      { type: "triangle", detune: 12 }
+    ],
+    filterCutoff: 4200,
+    filterResonance: 14,
+    envelope: { attack: 0.01, decay: 0.18, sustain: 0.35, release: 0.25 },
+    gain: 0.5
+  },
+  "velvet-keys": {
+    id: "velvet-keys",
+    name: "Velvet Keys",
+    oscillators: [
+      { type: "sine", detune: -5 },
+      { type: "sine", detune: 5 }
+    ],
+    filterCutoff: 2600,
+    filterResonance: 9,
+    envelope: { attack: 0.08, decay: 0.32, sustain: 0.7, release: 0.9 },
+    gain: 0.58
+  }
+};
+
+const pianoGrid = document.getElementById("pianoGrid");
+const drumGrid = document.getElementById("drumGrid");
+const tempoInput = document.getElementById("tempo");
+const tempoDisplay = document.getElementById("tempoDisplay");
+const swingInput = document.getElementById("swing");
+const swingDisplay = document.getElementById("swingDisplay");
+const playButton = document.getElementById("playButton");
+const stopButton = document.getElementById("stopButton");
+const clearPatternButton = document.getElementById("clearPattern");
+const seedPatternButton = document.getElementById("seedPattern");
+const sceneNameInput = document.getElementById("sceneName");
+const sceneRepeatsInput = document.getElementById("sceneRepeats");
+const addSceneButton = document.getElementById("addScene");
+const arrangementList = document.getElementById("arrangementList");
+const clearArrangementButton = document.getElementById("clearArrangement");
+const sceneDisplay = document.getElementById("sceneDisplay");
+const synthPresetSelect = document.getElementById("synthPreset");
+const filterCutoffInput = document.getElementById("filterCutoff");
+const filterCutoffDisplay = document.getElementById("filterCutoffDisplay");
+const filterResonanceInput = document.getElementById("filterResonance");
+const filterResonanceDisplay = document.getElementById("filterResonanceDisplay");
+const attackInput = document.getElementById("attack");
+const attackDisplay = document.getElementById("attackDisplay");
+const releaseInput = document.getElementById("release");
+const releaseDisplay = document.getElementById("releaseDisplay");
+
+const pianoState = pianoNotes.map(() => Array(steps).fill(false));
+const drumState = drumTracks.map(() => Array(steps).fill(false));
+const pianoCells = pianoNotes.map(() => Array(steps));
+const drumCells = drumTracks.map(() => Array(steps));
+
+const arrangementState = [];
+let selectedSceneId = null;
+let arrangementMode = false;
+let activeSceneIndex = -1;
+let activeSceneRepeats = 0;
+
+let audioCtx;
+let masterGain;
+let noiseBuffer;
+let isPlaying = false;
+let currentStep = 0;
+let timerId;
+
+let synthSettings = clonePreset(synthPresets[synthPresetSelect.value]);
+
+buildPianoGrid();
+buildDrumGrid();
+updateTempoDisplay();
+updateSwingDisplay();
+refreshCells();
+applySynthControls();
+setSceneLabel("Live Pattern");
+seedDemoPattern();
+
+stopButton.disabled = true;
+
+playButton.addEventListener("click", startPlayback);
+stopButton.addEventListener("click", () => stopPlayback(false));
+clearPatternButton.addEventListener("click", () => {
+  clearPattern();
+  selectedSceneId = null;
+  setSceneLabel("Live Pattern");
+});
+seedPatternButton.addEventListener("click", () => {
+  clearPattern();
+  seedDemoPattern();
+  selectedSceneId = null;
+  setSceneLabel("Pattern Demo");
+});
+
+tempoInput.addEventListener("input", updateTempoDisplay);
+swingInput.addEventListener("input", updateSwingDisplay);
+
+addSceneButton.addEventListener("click", addSceneFromCurrentPattern);
+clearArrangementButton.addEventListener("click", () => {
+  arrangementState.splice(0, arrangementState.length);
+  selectedSceneId = null;
+  renderArrangementList();
+  setSceneLabel("Live Pattern");
+});
+
+arrangementList.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-action]");
+  if (!button) return;
+
+  const { action, id } = button.dataset;
+  const index = arrangementState.findIndex((scene) => scene.id === id);
+  if (index === -1) return;
+
+  switch (action) {
+    case "load":
+      loadSceneForEditing(arrangementState[index]);
+      break;
+    case "remove":
+      arrangementState.splice(index, 1);
+      if (selectedSceneId === id) {
+        selectedSceneId = null;
+        setSceneLabel("Live Pattern");
+      }
+      renderArrangementList();
+      break;
+    case "up":
+      if (index > 0) {
+        moveScene(index, index - 1);
+      }
+      break;
+    case "down":
+      if (index < arrangementState.length - 1) {
+        moveScene(index, index + 1);
+      }
+      break;
+    default:
+      break;
+  }
+});
+
+synthPresetSelect.addEventListener("change", () => {
+  synthSettings = clonePreset(synthPresets[synthPresetSelect.value]);
+  applySynthControls();
+});
+
+filterCutoffInput.addEventListener("input", () => {
+  synthSettings.filterCutoff = Number.parseFloat(filterCutoffInput.value);
+  updateSynthDisplays();
+});
+
+filterResonanceInput.addEventListener("input", () => {
+  synthSettings.filterResonance = Number.parseFloat(filterResonanceInput.value);
+  updateSynthDisplays();
+});
+
+attackInput.addEventListener("input", () => {
+  synthSettings.envelope.attack = Number.parseFloat(attackInput.value);
+  updateSynthDisplays();
+});
+
+releaseInput.addEventListener("input", () => {
+  synthSettings.envelope.release = Number.parseFloat(releaseInput.value);
+  updateSynthDisplays();
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.code !== "Space" || event.repeat) return;
+  const target = event.target;
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)
+    return;
+  if (target && target.isContentEditable) return;
+  event.preventDefault();
+  if (isPlaying) {
+    stopPlayback(false);
+  } else {
+    startPlayback();
+  }
+});
+
+function buildPianoGrid() {
+  pianoGrid.innerHTML = "";
+  pianoNotes.forEach((note, rowIndex) => {
+    const row = document.createElement("div");
+    row.className = "note-row";
+
+    const label = document.createElement("div");
+    label.className = "note-label";
+    label.textContent = note;
+    row.appendChild(label);
+
+    for (let stepIndex = 0; stepIndex < steps; stepIndex += 1) {
+      const cell = createCell("piano", rowIndex, stepIndex);
+      row.appendChild(cell);
+      pianoCells[rowIndex][stepIndex] = cell;
+    }
+
+    pianoGrid.appendChild(row);
+  });
+}
+
+function buildDrumGrid() {
+  drumGrid.innerHTML = "";
+  drumTracks.forEach((track, rowIndex) => {
+    const row = document.createElement("div");
+    row.className = "pattern-row";
+
+    const label = document.createElement("div");
+    label.className = "note-label";
+    label.textContent = track.label;
+    row.appendChild(label);
+
+    for (let stepIndex = 0; stepIndex < steps; stepIndex += 1) {
+      const cell = createCell("drum", rowIndex, stepIndex);
+      row.appendChild(cell);
+      drumCells[rowIndex][stepIndex] = cell;
+    }
+
+    drumGrid.appendChild(row);
+  });
+}
+
+function createCell(type, rowIndex, stepIndex) {
+  const cell = document.createElement("div");
+  cell.className = "cell";
+  const button = document.createElement("button");
+  button.type = "button";
+  button.addEventListener("click", () => {
+    const isActive = toggleCell(type, rowIndex, stepIndex);
+    button.classList.toggle("active", isActive);
+  });
+  cell.appendChild(button);
+  return cell;
+}
+
+function toggleCell(type, rowIndex, stepIndex) {
+  if (type === "piano") {
+    pianoState[rowIndex][stepIndex] = !pianoState[rowIndex][stepIndex];
+    return pianoState[rowIndex][stepIndex];
+  }
+  drumState[rowIndex][stepIndex] = !drumState[rowIndex][stepIndex];
+  return drumState[rowIndex][stepIndex];
+}
+
+function addSceneFromCurrentPattern() {
+  const name = sceneNameInput.value.trim() || `Sezione ${arrangementState.length + 1}`;
+  const repeats = Math.max(1, Number.parseInt(sceneRepeatsInput.value, 10) || 1);
+  const pattern = snapshotPattern();
+  const scene = {
+    id: `scene-${(Date.now()).toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+    name,
+    repeats,
+    piano: pattern.piano,
+    drums: pattern.drums
+  };
+  arrangementState.push(scene);
+  sceneNameInput.value = "";
+  sceneRepeatsInput.value = repeats.toString();
+  renderArrangementList();
+  setSceneLabel(`Scene salvata: ${name}`);
+}
+
+function moveScene(from, to) {
+  const [scene] = arrangementState.splice(from, 1);
+  arrangementState.splice(to, 0, scene);
+  renderArrangementList();
+}
+
+function loadSceneForEditing(scene) {
+  injectPattern(scene.piano, scene.drums);
+  selectedSceneId = scene.id;
+  setSceneLabel(`Scene selezionata: ${scene.name}`);
+  renderArrangementList();
+}
+
+function snapshotPattern() {
+  return {
+    piano: pianoState.map((row) => [...row]),
+    drums: drumState.map((row) => [...row])
+  };
+}
+
+function injectPattern(pianoPattern, drumPattern) {
+  pianoPattern.forEach((row, rowIndex) => {
+    row.forEach((value, stepIndex) => {
+      pianoState[rowIndex][stepIndex] = value;
+    });
+  });
+  drumPattern.forEach((row, rowIndex) => {
+    row.forEach((value, stepIndex) => {
+      drumState[rowIndex][stepIndex] = value;
+    });
+  });
+  refreshCells();
+}
+
+function clearPattern() {
+  pianoState.forEach((row) => row.fill(false));
+  drumState.forEach((row) => row.fill(false));
+  refreshCells();
+}
+
+function seedDemoPattern() {
+  const melody = [
+    { note: "C5", steps: [0, 4, 8, 12] },
+    { note: "G4", steps: [2, 6, 10, 14] },
+    { note: "E4", steps: [4, 12] },
+    { note: "D4", steps: [7, 15] }
+  ];
+
+  melody.forEach(({ note, steps: activeSteps }) => {
+    const rowIndex = pianoNotes.indexOf(note);
+    if (rowIndex === -1) return;
+    activeSteps.forEach((stepIndex) => {
+      pianoState[rowIndex][stepIndex] = true;
+    });
+  });
+
+  const drumPattern = {
+    kick: [0, 4, 8, 12],
+    snare: [4, 12],
+    hat: Array.from({ length: steps }, (_, index) => index).filter((index) => index % 2 === 0)
+  };
+
+  drumTracks.forEach(({ id }, rowIndex) => {
+    const activeSteps = drumPattern[id] || [];
+    activeSteps.forEach((stepIndex) => {
+      drumState[rowIndex][stepIndex] = true;
+    });
+  });
+
+  refreshCells();
+}
+
+function refreshCells() {
+  pianoCells.forEach((row, rowIndex) => {
+    row.forEach((cell, stepIndex) => {
+      const button = cell.querySelector("button");
+      button.classList.toggle("active", pianoState[rowIndex][stepIndex]);
+      cell.classList.remove("playing");
+    });
+  });
+  drumCells.forEach((row, rowIndex) => {
+    row.forEach((cell, stepIndex) => {
+      const button = cell.querySelector("button");
+      button.classList.toggle("active", drumState[rowIndex][stepIndex]);
+      cell.classList.remove("playing");
+    });
+  });
+}
+
+function renderArrangementList() {
+  arrangementList.innerHTML = "";
+  arrangementState.forEach((scene) => {
+    const item = document.createElement("li");
+    if (scene.id === selectedSceneId) {
+      item.classList.add("active");
+    }
+
+    const meta = document.createElement("div");
+    meta.className = "arrangement-meta";
+    const title = document.createElement("strong");
+    title.textContent = scene.name;
+    const subtitle = document.createElement("span");
+    const totalNotes = scene.piano.reduce(
+      (sum, row) => sum + row.filter(Boolean).length,
+      0
+    );
+    subtitle.textContent = `${scene.repeats}x • ${totalNotes} eventi`;
+    meta.appendChild(title);
+    meta.appendChild(subtitle);
+
+    const actions = document.createElement("div");
+    actions.className = "scene-actions";
+    actions.appendChild(buildSceneActionButton("↑", "up", scene.id, "Sposta su"));
+    actions.appendChild(buildSceneActionButton("↓", "down", scene.id, "Sposta giù"));
+    actions.appendChild(buildSceneActionButton("⟳", "load", scene.id, "Carica scena"));
+    actions.appendChild(buildSceneActionButton("✕", "remove", scene.id, "Elimina"));
+
+    item.appendChild(meta);
+    item.appendChild(actions);
+    arrangementList.appendChild(item);
+  });
+}
+
+function buildSceneActionButton(label, action, id, title) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = label;
+  button.dataset.action = action;
+  button.dataset.id = id;
+  button.title = title;
+  return button;
+}
+
+function startPlayback() {
+  if (isPlaying) return;
+  const context = ensureAudioContext();
+  context.resume();
+
+  isPlaying = true;
+  arrangementMode = arrangementState.length > 0;
+  activeSceneIndex = -1;
+  activeSceneRepeats = 0;
+  currentStep = 0;
+  highlightStep(null);
+  playButton.disabled = true;
+  stopButton.disabled = false;
+
+  if (arrangementMode) {
+    switchToScene(0);
+  }
+
+  runStep();
+}
+
+function stopPlayback(completed) {
+  if (!isPlaying) return;
+  isPlaying = false;
+  if (timerId) {
+    clearTimeout(timerId);
+    timerId = undefined;
+  }
+  highlightStep(null);
+  playButton.disabled = false;
+  stopButton.disabled = true;
+  arrangementMode = false;
+  activeSceneIndex = -1;
+  activeSceneRepeats = 0;
+  if (!completed) {
+    setSceneLabel(selectedSceneId ? sceneLabelForSelected() : "Live Pattern");
+  } else {
+    setSceneLabel("Struttura completata");
+  }
+}
+
+function runStep() {
+  if (!isPlaying) {
+    return;
+  }
+
+  const context = ensureAudioContext();
+  const tempo = Number.parseInt(tempoInput.value, 10);
+  const swing = Number.parseFloat(swingInput.value);
+  const stepDuration = 60 / tempo / 4;
+  const startTime = context.currentTime + 0.02;
+
+  triggerPiano(currentStep, startTime, stepDuration);
+  triggerDrums(currentStep, startTime);
+  highlightStep(currentStep);
+
+  currentStep = (currentStep + 1) % steps;
+
+  if (currentStep === 0 && arrangementMode) {
+    const currentScene = arrangementState[activeSceneIndex];
+    activeSceneRepeats += 1;
+    if (activeSceneRepeats >= currentScene.repeats) {
+      const nextIndex = activeSceneIndex + 1;
+      if (nextIndex >= arrangementState.length) {
+        stopPlayback(true);
+        return;
+      }
+      switchToScene(nextIndex);
+    } else {
+      setSceneLabel(buildArrangementLabel(currentScene, activeSceneRepeats + 1));
+    }
+  }
+
+  let nextInterval = stepDuration;
+  if (swing > 0) {
+    const swingAmount = stepDuration * swing;
+    const isEvenStep = currentStep % 2 === 0;
+    nextInterval = isEvenStep ? stepDuration - swingAmount : stepDuration + swingAmount;
+  }
+
+  timerId = setTimeout(runStep, Math.max(0.05, nextInterval) * 1000);
+}
+
+function switchToScene(index) {
+  activeSceneIndex = index;
+  activeSceneRepeats = 0;
+  const scene = arrangementState[index];
+  injectPattern(scene.piano, scene.drums);
+  selectedSceneId = scene.id;
+  currentStep = 0;
+  highlightStep(null);
+  setSceneLabel(buildArrangementLabel(scene, 1));
+  renderArrangementList();
+}
+
+function highlightStep(step) {
+  pianoCells.forEach((row) => {
+    row.forEach((cell, index) => {
+      cell.classList.toggle("playing", step === index);
+    });
+  });
+
+  drumCells.forEach((row) => {
+    row.forEach((cell, index) => {
+      cell.classList.toggle("playing", step === index);
+    });
+  });
+}
+
+function triggerPiano(step, startTime, duration) {
+  pianoState.forEach((row, rowIndex) => {
+    if (!row[step]) return;
+    const noteName = pianoNotes[rowIndex];
+    const frequency = noteToFrequency(noteName);
+    playSynthVoice(frequency, startTime, duration);
+  });
+}
+
+function triggerDrums(step, startTime) {
+  drumState.forEach((row, rowIndex) => {
+    if (!row[step]) return;
+
+    const id = drumTracks[rowIndex].id;
+    if (id === "kick") {
+      playKick(startTime);
+    } else if (id === "snare") {
+      playSnare(startTime);
+    } else {
+      playHat(startTime);
+    }
+  });
+}
+
+function ensureAudioContext() {
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+    masterGain = audioCtx.createGain();
+    masterGain.gain.value = 0.6;
+    masterGain.connect(audioCtx.destination);
+  }
+  return audioCtx;
+}
+
+function ensureNoiseBuffer() {
+  if (!noiseBuffer && audioCtx) {
+    noiseBuffer = audioCtx.createBuffer(1, audioCtx.sampleRate, audioCtx.sampleRate);
+    const data = noiseBuffer.getChannelData(0);
+    for (let i = 0; i < noiseBuffer.length; i += 1) {
+      data[i] = Math.random() * 2 - 1;
+    }
+  }
+  return noiseBuffer;
+}
+
+function playSynthVoice(frequency, startTime, duration) {
+  const context = ensureAudioContext();
+  const filter = context.createBiquadFilter();
+  filter.type = "lowpass";
+  filter.frequency.setValueAtTime(synthSettings.filterCutoff, startTime);
+  filter.Q.setValueAtTime(synthSettings.filterResonance, startTime);
+
+  const amp = context.createGain();
+  const { attack, decay, sustain, release } = synthSettings.envelope;
+  const level = synthSettings.gain;
+
+  amp.gain.cancelScheduledValues(startTime);
+  amp.gain.setValueAtTime(0.0001, startTime);
+  amp.gain.linearRampToValueAtTime(level, startTime + attack);
+  amp.gain.linearRampToValueAtTime(level * sustain, startTime + attack + decay);
+  const releaseStart = startTime + duration;
+  amp.gain.setValueAtTime(level * sustain, releaseStart);
+  amp.gain.linearRampToValueAtTime(0.0001, releaseStart + release);
+
+  const oscillators = synthSettings.oscillators.length
+    ? synthSettings.oscillators
+    : [{ type: "sawtooth", detune: 0 }];
+
+  const oscNodes = oscillators.map(({ type, detune }) => {
+    const osc = context.createOscillator();
+    osc.type = type;
+    osc.frequency.setValueAtTime(frequency, startTime);
+    osc.detune.setValueAtTime(detune || 0, startTime);
+    osc.connect(filter);
+    osc.start(startTime);
+    osc.stop(releaseStart + release + 0.1);
+    return osc;
+  });
+
+  filter.connect(amp).connect(masterGain);
+
+  oscNodes.forEach((osc) => {
+    osc.onended = () => {
+      osc.disconnect();
+    };
+  });
+}
+
+function playKick(startTime) {
+  const context = ensureAudioContext();
+  const osc = context.createOscillator();
+  const gain = context.createGain();
+
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(120, startTime);
+  osc.frequency.exponentialRampToValueAtTime(40, startTime + 0.28);
+
+  gain.gain.setValueAtTime(1, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, startTime + 0.32);
+
+  osc.connect(gain);
+  gain.connect(masterGain);
+
+  osc.start(startTime);
+  osc.stop(startTime + 0.36);
+}
+
+function playSnare(startTime) {
+  const context = ensureAudioContext();
+  const noise = context.createBufferSource();
+  noise.buffer = ensureNoiseBuffer();
+
+  const noiseFilter = context.createBiquadFilter();
+  noiseFilter.type = "bandpass";
+  noiseFilter.frequency.setValueAtTime(2200, startTime);
+  noiseFilter.Q.value = 1.1;
+
+  const noiseGain = context.createGain();
+  noiseGain.gain.setValueAtTime(0.75, startTime);
+  noiseGain.gain.exponentialRampToValueAtTime(0.01, startTime + 0.22);
+
+  const tone = context.createOscillator();
+  tone.type = "triangle";
+  tone.frequency.setValueAtTime(220, startTime);
+  tone.frequency.exponentialRampToValueAtTime(140, startTime + 0.18);
+
+  const toneGain = context.createGain();
+  toneGain.gain.setValueAtTime(0.5, startTime);
+  toneGain.gain.exponentialRampToValueAtTime(0.01, startTime + 0.18);
+
+  noise.connect(noiseFilter).connect(noiseGain).connect(masterGain);
+  tone.connect(toneGain).connect(masterGain);
+
+  noise.start(startTime);
+  noise.stop(startTime + 0.24);
+  tone.start(startTime);
+  tone.stop(startTime + 0.2);
+}
+
+function playHat(startTime) {
+  const context = ensureAudioContext();
+  const noise = context.createBufferSource();
+  noise.buffer = ensureNoiseBuffer();
+
+  const highpass = context.createBiquadFilter();
+  highpass.type = "highpass";
+  highpass.frequency.setValueAtTime(9000, startTime);
+  highpass.Q.value = 0.8;
+
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0.4, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, startTime + 0.12);
+
+  noise.connect(highpass).connect(gain).connect(masterGain);
+  noise.start(startTime);
+  noise.stop(startTime + 0.14);
+}
+
+function noteToFrequency(note) {
+  const [, pitch, octave] = note.match(/([A-G]#?)(\d)/);
+  const semitoneMap = {
+    C: -9,
+    "C#": -8,
+    D: -7,
+    "D#": -6,
+    E: -5,
+    F: -4,
+    "F#": -3,
+    G: -2,
+    "G#": -1,
+    A: 0,
+    "A#": 1,
+    B: 2
+  };
+  const semitonesFromA4 = (Number.parseInt(octave, 10) - 4) * 12 + semitoneMap[pitch];
+  return 440 * 2 ** (semitonesFromA4 / 12);
+}
+
+function updateTempoDisplay() {
+  tempoDisplay.textContent = `${tempoInput.value} BPM`;
+}
+
+function updateSwingDisplay() {
+  const swingPercentage = Math.round(Number.parseFloat(swingInput.value) * 100);
+  swingDisplay.textContent = `${swingPercentage}%`;
+}
+
+function applySynthControls() {
+  filterCutoffInput.value = synthSettings.filterCutoff;
+  filterResonanceInput.value = synthSettings.filterResonance;
+  attackInput.value = synthSettings.envelope.attack;
+  releaseInput.value = synthSettings.envelope.release;
+  updateSynthDisplays();
+}
+
+function updateSynthDisplays() {
+  filterCutoffDisplay.textContent = `${Math.round(synthSettings.filterCutoff)} Hz`;
+  filterResonanceDisplay.textContent = `Q ${synthSettings.filterResonance.toFixed(1)}`;
+  attackDisplay.textContent = `${synthSettings.envelope.attack.toFixed(2)} s`;
+  releaseDisplay.textContent = `${synthSettings.envelope.release.toFixed(2)} s`;
+}
+
+function clonePreset(preset) {
+  return {
+    id: preset.id,
+    name: preset.name,
+    oscillators: preset.oscillators.map((osc) => ({ ...osc })),
+    filterCutoff: preset.filterCutoff,
+    filterResonance: preset.filterResonance,
+    envelope: { ...preset.envelope },
+    gain: preset.gain
+  };
+}
+
+function setSceneLabel(text) {
+  sceneDisplay.textContent = text;
+}
+
+function buildArrangementLabel(scene, iteration) {
+  return `Struttura: ${scene.name} (${Math.min(iteration, scene.repeats)}/${scene.repeats})`;
+}
+
+function sceneLabelForSelected() {
+  const scene = arrangementState.find(({ id }) => id === selectedSceneId);
+  return scene ? `Scene selezionata: ${scene.name}` : "Live Pattern";
+}

--- a/daw/index.html
+++ b/daw/index.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Aurora Studio</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="daw-app">
+      <div class="glass-window">
+        <header class="window-top">
+          <div class="window-controls" aria-hidden="true">
+            <span class="dot dot-close"></span>
+            <span class="dot dot-min"></span>
+            <span class="dot dot-max"></span>
+          </div>
+          <div class="title-cluster">
+            <span class="brand">Aurora Studio</span>
+            <span class="session-label" id="sceneDisplay">Live Pattern</span>
+          </div>
+          <div class="transport-cluster">
+            <button id="playButton" class="btn btn-transport primary" type="button">
+              <span aria-hidden="true">&#9658;</span>
+              Play
+            </button>
+            <button id="stopButton" class="btn btn-transport" type="button">
+              <span aria-hidden="true">&#9632;</span>
+              Stop
+            </button>
+          </div>
+        </header>
+
+        <main class="main-grid">
+          <aside class="side-panel controls">
+            <section class="card session-card">
+              <h2>Sessione</h2>
+              <label class="slider-field">
+                <span>Tempo</span>
+                <input id="tempo" type="range" min="60" max="180" value="110" />
+                <output id="tempoDisplay">110 BPM</output>
+              </label>
+              <label class="slider-field">
+                <span>Swing</span>
+                <input id="swing" type="range" min="0" max="0.22" step="0.01" value="0" />
+                <output id="swingDisplay">0%</output>
+              </label>
+              <div class="button-row">
+                <button id="clearPattern" class="btn ghost" type="button">Azzera loop</button>
+                <button id="seedPattern" class="btn ghost" type="button">Carica demo</button>
+              </div>
+            </section>
+
+            <section class="card synth-card">
+              <h2>Synth Designer</h2>
+              <label class="select-field">
+                <span>Preset</span>
+                <select id="synthPreset">
+                  <option value="aurora-lead">Aurora Lead</option>
+                  <option value="midnight-pad">Midnight Pad</option>
+                  <option value="glacier-pluck">Glacier Pluck</option>
+                  <option value="velvet-keys">Velvet Keys</option>
+                </select>
+              </label>
+              <label class="slider-field">
+                <span>Cutoff</span>
+                <input id="filterCutoff" type="range" min="400" max="8000" step="50" />
+                <output id="filterCutoffDisplay">0 Hz</output>
+              </label>
+              <label class="slider-field">
+                <span>Risonanza</span>
+                <input id="filterResonance" type="range" min="0.1" max="18" step="0.1" />
+                <output id="filterResonanceDisplay">0</output>
+              </label>
+              <div class="dual-slider">
+                <label class="slider-field">
+                  <span>Attack</span>
+                  <input id="attack" type="range" min="0" max="1.5" step="0.01" />
+                  <output id="attackDisplay">0s</output>
+                </label>
+                <label class="slider-field">
+                  <span>Release</span>
+                  <input id="release" type="range" min="0.1" max="3" step="0.01" />
+                  <output id="releaseDisplay">0s</output>
+                </label>
+              </div>
+            </section>
+          </aside>
+
+          <section class="center-panel">
+            <article class="panel piano-panel">
+              <header class="panel-header">
+                <div>
+                  <h2>Piano Roll</h2>
+                  <p>Programma melodie a 16 step</p>
+                </div>
+              </header>
+              <div id="pianoGrid" class="grid"></div>
+            </article>
+
+            <article class="panel drum-panel">
+              <header class="panel-header">
+                <div>
+                  <h2>Sezione Ritmica</h2>
+                  <p>Kick, Snare, Hi-Hat</p>
+                </div>
+              </header>
+              <div id="drumGrid" class="grid drum-grid"></div>
+            </article>
+          </section>
+
+          <aside class="side-panel arrangement">
+            <section class="card">
+              <h2>Struttura</h2>
+              <p class="card-subtitle">
+                Crea scene e ordina la tua composizione.
+              </p>
+              <div class="arrangement-form">
+                <label>
+                  Nome sezione
+                  <input id="sceneName" type="text" placeholder="Bridge, Chorus..." />
+                </label>
+                <label>
+                  Ripetizioni
+                  <input id="sceneRepeats" type="number" min="1" max="8" value="2" />
+                </label>
+                <button id="addScene" class="btn" type="button">Aggiungi</button>
+              </div>
+              <ul id="arrangementList" class="arrangement-list" aria-live="polite"></ul>
+              <div class="arrangement-actions">
+                <button id="clearArrangement" class="btn ghost" type="button">
+                  Svuota struttura
+                </button>
+              </div>
+            </section>
+          </aside>
+        </main>
+      </div>
+    </div>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/daw/styles.css
+++ b/daw/styles.css
@@ -1,0 +1,520 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at top, #1f2937, #0f172a 55%, #020617 100%);
+  --panel-bg: rgba(20, 24, 38, 0.72);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --panel-highlight: rgba(255, 255, 255, 0.16);
+  --accent: #66d9ef;
+  --accent-strong: #41b6ff;
+  --accent-soft: rgba(102, 217, 239, 0.2);
+  --accent-glow: 0 12px 40px rgba(65, 182, 255, 0.25);
+  --text-primary: #f4f7fb;
+  --text-secondary: rgba(244, 247, 251, 0.7);
+  --grid-border: rgba(255, 255, 255, 0.08);
+  --grid-odd: rgba(255, 255, 255, 0.04);
+  --grid-even: rgba(255, 255, 255, 0.02);
+  --row-label: rgba(244, 247, 251, 0.12);
+  --danger: #ff6b6b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  font-family: "Inter", "SF Pro Display", "SF Pro Text", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5vh 2.5vw;
+}
+
+.daw-app {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.glass-window {
+  width: min(1120px, 96vw);
+  height: min(720px, 92vh);
+  backdrop-filter: blur(26px) saturate(140%);
+  background: rgba(8, 12, 24, 0.68);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 40px 80px rgba(2, 6, 23, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.window-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 28px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: linear-gradient(135deg, rgba(24, 32, 48, 0.78), rgba(12, 18, 32, 0.78));
+}
+
+.window-controls {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.window-controls .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.24);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.35);
+}
+
+.dot-close {
+  background: linear-gradient(145deg, #ff6b6b, #ef4444);
+}
+
+.dot-min {
+  background: linear-gradient(145deg, #facc15, #eab308);
+}
+
+.dot-max {
+  background: linear-gradient(145deg, #34d399, #10b981);
+}
+
+.title-cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+}
+
+.brand {
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.session-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.transport-cluster {
+  display: inline-flex;
+  gap: 12px;
+}
+
+.btn {
+  appearance: none;
+  border: none;
+  border-radius: 14px;
+  padding: 10px 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #081120;
+  box-shadow: var(--accent-glow);
+}
+
+.btn.ghost {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.btn-transport {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  padding: 10px 22px;
+}
+
+.main-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 20%) 1fr minmax(260px, 24%);
+  gap: 22px;
+  padding: 24px 28px 28px;
+  flex: 1;
+}
+
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.card {
+  background: var(--panel-bg);
+  border-radius: 22px;
+  border: 1px solid var(--panel-border);
+  padding: 20px 22px;
+  box-shadow: inset 0 1px 0 var(--panel-highlight);
+}
+
+.card h2 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card-subtitle {
+  margin: -8px 0 16px;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.slider-field,
+.select-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.slider-field input[type="range"] {
+  width: 100%;
+  -webkit-appearance: none;
+  height: 6px;
+  border-radius: 10px;
+  background: linear-gradient(90deg, rgba(102, 217, 239, 0.5), rgba(14, 116, 144, 0.3));
+  outline: none;
+}
+
+.slider-field input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(102, 217, 239, 0.2);
+  transition: transform 0.15s ease;
+}
+
+.slider-field input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+.slider-field output {
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  opacity: 0.72;
+}
+
+.select-field select,
+.arrangement-form input[type="text"],
+.arrangement-form input[type="number"] {
+  width: 100%;
+  border-radius: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+}
+
+.arrangement-form {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.arrangement-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.arrangement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.arrangement-list li {
+  background: rgba(8, 14, 28, 0.72);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 12px 14px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 14px;
+  align-items: center;
+}
+
+.arrangement-list li.active {
+  border-color: var(--accent);
+  box-shadow: 0 8px 18px rgba(102, 217, 239, 0.25);
+}
+
+.arrangement-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.arrangement-meta strong {
+  font-size: 0.9rem;
+}
+
+.arrangement-meta span {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.arrangement-actions {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.scene-actions {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.scene-actions button {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.scene-actions button:hover {
+  transform: translateY(-1px);
+}
+
+.center-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 26px;
+  border: 1px solid var(--panel-border);
+  padding: 18px 22px 24px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: inset 0 1px 0 var(--panel-highlight);
+  min-height: 0;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 12px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.panel-header p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.grid {
+  flex: 1;
+  background: rgba(7, 10, 20, 0.72);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.note-row,
+.pattern-row {
+  display: grid;
+  grid-template-columns: 80px repeat(16, 1fr);
+  gap: 4px;
+  align-items: stretch;
+}
+
+.note-label {
+  background: var(--row-label);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.cell {
+  position: relative;
+  padding-top: 100%;
+}
+
+.cell button {
+  position: absolute;
+  inset: 0;
+  border: none;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.cell:nth-child(even) button {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.cell button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.38);
+}
+
+.cell button.active {
+  background: linear-gradient(145deg, rgba(102, 217, 239, 0.85), rgba(65, 182, 255, 0.85));
+  color: #02101f;
+  box-shadow: 0 10px 24px rgba(102, 217, 239, 0.45);
+}
+
+.cell.playing button {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: -2px;
+  filter: brightness(1.1);
+}
+
+.grid::-webkit-scrollbar,
+.arrangement-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.grid::-webkit-scrollbar-thumb,
+.arrangement-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+}
+
+.button-row {
+  display: flex;
+  gap: 10px;
+}
+
+.dual-slider {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 1180px) {
+  .glass-window {
+    height: 94vh;
+  }
+
+  .main-grid {
+    grid-template-columns: minmax(220px, 24%) 1fr minmax(240px, 26%);
+  }
+}
+
+@media (max-width: 1024px) {
+  body {
+    padding: 1.5vh 1.5vw;
+  }
+
+  .glass-window {
+    width: 100%;
+  }
+
+  .main-grid {
+    grid-template-columns: 240px 1fr 240px;
+    gap: 18px;
+    padding: 20px;
+  }
+
+  .panel {
+    padding: 16px 18px 20px;
+  }
+}
+
+@media (max-width: 900px) {
+  .main-grid {
+    grid-template-columns: minmax(200px, 28%) 1fr;
+    grid-template-areas:
+      "controls center"
+      "arrangement center";
+    grid-auto-rows: minmax(0, 1fr);
+  }
+
+  .controls {
+    grid-area: controls;
+  }
+
+  .arrangement {
+    grid-area: arrangement;
+  }
+
+  .center-panel {
+    grid-column: span 2;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the `/daw` experience with an Apple-inspired full-window layout and responsive glassmorphic panels
- add arrangement tools, spacebar transport control, and progress-aware scene playback for building musical structures
- expand the synth designer with editable filter/envelope controls and curated presets while keeping the Web Audio sequencer

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc4bbc9bbc832e926aed59514bc86e